### PR TITLE
fix(ux): improve search result message to avoid confusion

### DIFF
--- a/src/commands/ombi/movie.js
+++ b/src/commands/ombi/movie.js
@@ -126,7 +126,7 @@ module.exports = class searchMovieCommand extends commando.Command {
 
 				// output search results in embed
 				movieEmbed.setTitle('Ombi Movie Search')
-				.setDescription('Please select one of the search results. To abort answer **cancel**')
+				.setDescription('To select one of the search results, respond with its number. To abort answer **cancel**')
 				.addField('__Search Results__', fieldContent);
 				msg.embed(movieEmbed);
 

--- a/src/commands/ombi/tv.js
+++ b/src/commands/ombi/tv.js
@@ -128,7 +128,7 @@ module.exports = class searchTVCommand extends commando.Command {
 
 				// output search results in embed
 				showEmbed.setTitle('Ombi TV Show Search')
-				.setDescription('Please select one of the search results. To abort answer **cancel**')
+				.setDescription('To select one of the search results, respond with its number. To abort answer **cancel**')
 				.addField('__Search Results__', fieldContent);
 				msg.embed(showEmbed);
 


### PR DESCRIPTION
I was having trouble on my server, where people who aren't used to Chat Bots clicking on the Movie / TV show name instead of responding with it's id (🤣). Hence, a more clearer message explains what to do. 

Warning : This PR does not guarantee your users to be adept at using the bot correctly. 