### PR TITLE
Added TV season limit

### DIFF
--- a/src/Database.js
+++ b/src/Database.js
@@ -35,8 +35,8 @@ class Database {
                 [request.body.token, request.body.ownerID, request.body.commandPrefix, (request.body.deleteCommandMessages) ? 'true' : 'false', (request.body.unknownCommandResponse) ? 'true' : 'false']);
         } else if (request.path == '/ombi' && request.body.apiKey != '' && request.body.host != '') {
             this.db.run('DELETE FROM ' + request.path.replace('/', ''));
-            this.db.run('INSERT INTO ombi (host, port, apikey, requesttv, requestmovie, username) VALUES(?, ?, ?, ?, ?, ?)',
-                [request.body.host, request.body.port, request.body.apiKey, request.body.requestTV, request.body.requestMovie, request.body.userName]);
+            this.db.run('INSERT INTO ombi (host, port, apikey, requesttv, requestmovie, username, limittvrequests) VALUES(?, ?, ?, ?, ?, ?, ?)',
+                [request.body.host, request.body.port, request.body.apiKey, request.body.requestTV, request.body.requestMovie, request.body.userName, request.body.limitTVRequest]);
         } else if ((request.path == '/tautulli' || request.path == '/sonarr' || request.path == '/radarr') && request.body.apiKey != '' && request.body.host != '') {
             this.db.run('DELETE FROM ' + request.path.replace('/', ''));
             this.db.run('INSERT INTO placeholder (host, port, apikey) VALUES(?, ?, ?)'.replace('placeholder', request.path.replace('/', '')),

--- a/src/commands/ombi/tv.js
+++ b/src/commands/ombi/tv.js
@@ -47,16 +47,14 @@ function requestTVShow(ombi, msg, showMsg, show) {
 				}).then((resolve) => {
 				// parse body into json objects
 				    let data = JSON.parse(resolve.body);
-				    //console.log((data.seasonRequests).length);
-				    //console.log(data.status);
 				    let body = "";
 				    let response = "";
-				    if (data.status != 'Ended' && (data.seasonRequests).length > 4) { //If a show is still running and has had more than 4 seasons, only request the most recent season to avoid a large backlog.
+				    if (ombi.limittvrequest > 0 && data.status != 'Ended' && (data.seasonRequests).length > ombi.limittvrequests) { //If user has set a backlog limit on TV season requests
 					body = JSON.stringify({ "tvDbId": show.id, "latestSeason" : true });
 					response = 'Only the latest season was requested.';
 				    } else {
 					body = JSON.stringify({ "tvDbId": show.id, "requestAll" : true });
-					response = 'All seasons were requested.';
+					response = 'All ' + (data.seasonRequests).length + ' seasons were requested.';
 				    }
 				    post({
 					    headers: {'accept' : 'application/json',

--- a/src/commands/ombi/tv.js
+++ b/src/commands/ombi/tv.js
@@ -60,8 +60,8 @@ function requestTVShow(ombi, msg, showMsg, show) {
 					    headers: {'accept' : 'application/json',
 					    'Content-Type' : 'application/json',
 					    'ApiKey' : ombi.apikey,
-								'ApiAlias' : `${msg.author.username} (${msg.author.id})`,
-								'UserName': 'BigBox Requests',
+					    'ApiAlias' : `${msg.author.username} (${msg.author.id})`,
+				            'UserName': (ombi.username !== "") ? ombi.username : '',
 					    'User-Agent': `Mellow/${process.env.npm_package_version}`},
 					    url: 'http://' + ombi.host + ((ombi.port) ? ':' + ombi.port : '') + '/api/v1/Request/tv/',
 					    body: body

--- a/src/views/config.ejs
+++ b/src/views/config.ejs
@@ -63,6 +63,9 @@
     <h2 class="h2-setting">Request TV Shows (Discord Role Name)</h2>
     <input type = "text" class = "form-control" name = "requestTV" value = "<% if (ombiSettings && ombiSettings.requesttv) { %><%=ombiSettings.requesttv %><% } %>">
     <p>(Leave blank if anyone can request.)</p>
+    <h2 class="h2-setting">How many seasons backlog for running TV shows</h2>
+    <input type = "text" class = "form-control" name = "limitTVRequest" value "<% if (ombiSettings && ombiSettings.limittvrequest) { %><%=ombiSettings.limittvrequest %><% } %>">
+    <p>(Leave blank to default to all seasons.)</p>
     <h2 class="h2-setting">Request Movies (Discord Role Name)</h2>
     <input type = "text" class = "form-control" name = "requestMovie" value = "<% if (ombiSettings && ombiSettings.requestmovie) { %><%=ombiSettings.requestmovie %><% } %>">
     <p>(Leave blank if anyone can request.)</p>

--- a/src/views/config.ejs
+++ b/src/views/config.ejs
@@ -63,9 +63,9 @@
     <h2 class="h2-setting">Request TV Shows (Discord Role Name)</h2>
     <input type = "text" class = "form-control" name = "requestTV" value = "<% if (ombiSettings && ombiSettings.requesttv) { %><%=ombiSettings.requesttv %><% } %>">
     <p>(Leave blank if anyone can request.)</p>
-    <h2 class="h2-setting">How many seasons backlog for running TV shows</h2>
+    <h2 class="h2-setting">Running show cut-off</h2>
     <input type = "text" class = "form-control" name = "limitTVRequest" value "<% if (ombiSettings && ombiSettings.limittvrequest) { %><%=ombiSettings.limittvrequest %><% } %>">
-    <p>(Leave blank to default to all seasons.)</p>
+    <p>(If a running show has more than _ seasons, only grab the latest season. Leave blank to default to all seasons.)</p>
     <h2 class="h2-setting">Request Movies (Discord Role Name)</h2>
     <input type = "text" class = "form-control" name = "requestMovie" value = "<% if (ombiSettings && ombiSettings.requestmovie) { %><%=ombiSettings.requestmovie %><% } %>">
     <p>(Leave blank if anyone can request.)</p>


### PR DESCRIPTION
I'm tired of someone requesting some long-running TV show through Mellow and me getting stuck with a 40-season long backlog when all they really want to watch is the latest season.
In settings, users can indicate the cut-off count (if a running show has more than _ seasons, only grab the latest one). tv.js updated to make an additional Ombi API call for show info, compares season count to user setting, and requests either allSeasons or latestSeason of show accordingly.