### PR TITLE
Test API buttons

### DIFF
--- a/src/WebServer.js
+++ b/src/WebServer.js
@@ -3,6 +3,8 @@ const session = require('express-session');
 const path = require('path');
 const BotClient = require('./BotClient.js');
 
+const {get, getURL} = require('./util.js');
+
 
 class WebServer {
     constructor (WebDatabase, bot) {
@@ -70,6 +72,48 @@ class WebServer {
         }
     }
 
+    testApi(api) {
+        // todo: stuff
+        let config = this.WebDatabase.webConfig;
+        let url;
+        let apiHeader = {};
+        switch (api) {
+            case "ombi":
+                apiHeader = {'ApiKey': config.ombi.apikey};
+                url = getURL(config.ombi.host, config.ombi.port, config.ombi.ssl, config.ombi.baseurl + '/api/v1/Status/info');
+                break;
+            case "tautulli":
+                url = getURL(config.tautulli.host, config.tautulli.port, config.tautulli.ssl, config.tautulli.baseurl + '/api/v2?apikey=' + config.tautulli.apikey + '&cmd=status');
+                break;
+            case "sonarr":
+                url = getURL(config.sonarr.host, config.sonarr.port, config.sonarr.ssl, config.sonarr.baseurl + '/api/system/status?apikey=' + config.sonarr.apikey);
+                break;
+            case "radarr":
+                url = getURL(config.radarr.host, config.radarr.port, config.radarr.ssl, config.radarr.baseurl + '/api/system/status?apikey=' + config.radarr.apikey);
+                break;
+            default:
+                // no idea what api it is, so fail anyway
+                return (req, res) => {
+                    res.status(500).send(JSON.stringify({'status': 'error'}));
+                }
+        }
+        console.log(url);
+
+        return (req, res) => {
+            get({
+                headers: {'accept' : 'application/json',
+                    'User-Agent': `Mellow/${process.env.npm_package_version}`},
+                url: url
+            }).then((resolve) => {
+                res.setHeader('Content-Type', 'application/json');
+                res.send(resolve.body);
+            }).catch((error) => {
+                console.log(error);
+                res.status(500).send(JSON.stringify({'status': 'error'}));
+            });
+        }
+    }
+
     async init () {
         try {
             this.app.set('view engine', 'ejs');
@@ -115,6 +159,12 @@ class WebServer {
             this.app.post('/sonarr', this.onConfigSave());
             this.app.post('/radarr', this.onConfigSave());
             this.app.post('/logout', this.onLogout());
+
+            this.app.get('/ombi/test', this.testApi('ombi'));
+            this.app.get('/tautulli/test', this.testApi('tautulli'));
+            this.app.get('/sonarr/test', this.testApi('sonarr'));
+            this.app.get('/radarr/test', this.testApi('radarr'));
+
 
             this.app.listen(5060, this.onReady());
         } catch(error) {

--- a/src/WebServer.js
+++ b/src/WebServer.js
@@ -114,10 +114,17 @@ class WebServer {
                     url: url
                 }).then((resolve) => {
                     res.setHeader('Content-Type', 'application/json');
-                    res.send(resolve.body);
+
+                    // check that there is actually JSON supplied
+                    try {
+                        JSON.parse(resolve.body);
+                        res.send(resolve.body);
+                    } catch (e) {
+                        res.status(500).send(JSON.stringify({...{response: error}, ...{status: 'error'}}));
+                    }
                 }).catch((error) => {
                     // if there was an error, throw a 500 and provide more details on the error, if available
-                    res.status(500).send(JSON.stringify({...{response: error.body}, ...{status: 'error'}}));
+                    res.status(500).send(JSON.stringify({...{response: error}, ...{status: 'error'}}));
                 });
             }
         }
@@ -173,7 +180,7 @@ class WebServer {
             this.app.get('/tautulli/test', this.testApi('tautulli'));
             this.app.get('/sonarr/test', this.testApi('sonarr'));
             this.app.get('/radarr/test', this.testApi('radarr'));
-            
+
             this.app.listen(5060, this.onReady());
         } catch(error) {
             console.error(error);

--- a/src/WebServer.js
+++ b/src/WebServer.js
@@ -97,26 +97,29 @@ class WebServer {
                     break;
                 default:
                     // no idea what api it is, so fail anyway
-                    return (req, res) => {
-                        res.status(500).send(JSON.stringify({'status': 'error'}));
-                    }
+                    res.status(500).send(JSON.stringify({'status': 'error'}));
+                    break;
             }
 
-            let defaultHeaders = {'accept' : 'application/json',
-                'User-Agent': `Mellow/${process.env.npm_package_version}`};
+            if (url) {
+                let defaultHeaders = {
+                    'accept': 'application/json',
+                    'User-Agent': `Mellow/${process.env.npm_package_version}`
+                };
 
-            let requestHeaders = {...defaultHeaders, ...apiHeader};
+                let requestHeaders = {...defaultHeaders, ...apiHeader};
 
-            get({
-                headers: requestHeaders,
-                url: url
-            }).then((resolve) => {
-                res.setHeader('Content-Type', 'application/json');
-                res.send(resolve.body);
-            }).catch((error) => {
-                // if there was an error, throw a 500 and provide more details on the error, if available
-                res.status(500).send(JSON.stringify({...{response: error.body},...{status: 'error'}}));
-            });
+                get({
+                    headers: requestHeaders,
+                    url: url
+                }).then((resolve) => {
+                    res.setHeader('Content-Type', 'application/json');
+                    res.send(resolve.body);
+                }).catch((error) => {
+                    // if there was an error, throw a 500 and provide more details on the error, if available
+                    res.status(500).send(JSON.stringify({...{response: error.body}, ...{status: 'error'}}));
+                });
+            }
         }
     }
 

--- a/src/WebServer.js
+++ b/src/WebServer.js
@@ -173,8 +173,7 @@ class WebServer {
             this.app.get('/tautulli/test', this.testApi('tautulli'));
             this.app.get('/sonarr/test', this.testApi('sonarr'));
             this.app.get('/radarr/test', this.testApi('radarr'));
-
-
+            
             this.app.listen(5060, this.onReady());
         } catch(error) {
             console.error(error);

--- a/src/util.js
+++ b/src/util.js
@@ -23,8 +23,16 @@ const momentFormat = function (date, client) {
 const get = function(options) {
     return new Promise(function(resolve, reject) {
         request.get(options, function(error, response, body){
-            if (!error && response.statusCode == 200) resolve({response, body});
-            else reject({error, body});
+            if (!error && response.statusCode == 200) {
+                resolve({response, body});
+            } else {
+                if (response) {
+                    // return a status code to help with diagnosing api failures
+                    reject({error, body, 'statusCode':response.statusCode});
+                } else {
+                    reject({error, body});
+                }
+            }
         });
     });
 }

--- a/src/views/config.ejs
+++ b/src/views/config.ejs
@@ -251,9 +251,16 @@
           let buildMsg;
           if ((res.status === "error")) {
               buildMsg = "Connection failed. ";
-              if ((api === "tautulli")) {
-                  let detail = JSON.parse(res.response);
-                  buildMsg += detail.response.message;
+
+              let hardFailures = [400, 403, 404, 502];
+
+              if (hardFailures.includes(res.response.statusCode)) {
+                  buildMsg += res.response.statusCode;
+              } else {
+                  if ((api === "tautulli") && (res.response.body)) {
+                        let detail = JSON.parse(res.response.body);
+                        buildMsg += detail.response.message;
+                  }
               }
               setFailedMsg(buildMsg, api);
           } else {

--- a/src/views/config.ejs
+++ b/src/views/config.ejs
@@ -81,7 +81,6 @@
     <input type = "text" class = "form-control" name = "userName" value = "<% if (ombiSettings && ombiSettings.username) { %><%=ombiSettings.username %><% } %>">
     <p>(Enter Ombi username if you want custom permissions.)</p>
     <button class = "btn btn-lg btn-primary btn-block" type = "submit" name = "submit">Submit</button>
-
     <button class = "btn btn-lg btn-secondary btn-block" type = "button" onclick="testApi('ombi');" >Test API</button>
     <span id="ombiStatusOk" style="font-weight:bold;color:green;"></span>
     <span id="ombiStatusFailed" style="font-weight:bold;color:red;"></span>

--- a/src/views/config.ejs
+++ b/src/views/config.ejs
@@ -81,6 +81,10 @@
     <input type = "text" class = "form-control" name = "userName" value = "<% if (ombiSettings && ombiSettings.username) { %><%=ombiSettings.username %><% } %>">
     <p>(Enter Ombi username if you want custom permissions.)</p>
     <button class = "btn btn-lg btn-primary btn-block" type = "submit" name = "submit">Submit</button>
+
+    <button class = "btn btn-lg btn-secondary btn-block" type = "button" onclick="testApi('ombi');" >Test API</button>
+    <span id="ombiStatusOk" style="font-weight:bold;color:green;"></span>
+    <span id="ombiStatusFailed" style="font-weight:bold;color:red;"></span>
   </form>
 </div>
 
@@ -102,6 +106,9 @@
     </div>
     <h2 class="h2-setting">SSL</h2>
     <button class = "btn btn-lg btn-primary btn-block" type = "submit" name = "submit">Submit</button>
+    <button class = "btn btn-lg btn-secondary btn-block" type = "button" onclick="testApi('tautulli');" >Test API</button>
+    <span id="tautulliStatusOk" style="font-weight:bold;color:green;"></span>
+    <span id="tautulliStatusFailed" style="font-weight:bold;color:red;"></span>
   </form>
 </div>
 
@@ -123,6 +130,9 @@
     </div>
     <h2 class="h2-setting">SSL</h2>
     <button class = "btn btn-lg btn-primary btn-block" type = "submit" name = "submit">Submit</button>
+    <button class = "btn btn-lg btn-secondary btn-block" type = "button" onclick="testApi('sonarr');" >Test API</button>
+    <span id="sonarrStatusOk" style="font-weight:bold;color:green;"></span>
+    <span id="sonarrStatusFailed" style="font-weight:bold;color:red;"></span>
   </form>
 </div>
 
@@ -144,6 +154,9 @@
     </div>
     <h2 class="h2-setting">SSL</h2>
     <button class = "btn btn-lg btn-primary btn-block" type = "submit" name = "submit">Submit</button>
+    <button class = "btn btn-lg btn-secondary btn-block" type = "button" onclick="testApi('radarr');" >Test API</button>
+    <span id="radarrStatusOk" style="font-weight:bold;color:green;"></span>
+    <span id="radarrStatusFailed" style="font-weight:bold;color:red;"></span>
   </form>
 </div>
 
@@ -156,5 +169,55 @@
       }
       document.getElementById(settingName).style.display = "block";  
       currentSetting = settingName;
+  }
+
+  function test() {
+      console.log('hello');
+  }
+
+  function setSuccessMsg(msg, api) {
+      document.getElementById(api + 'StatusOk').innerHTML = msg;
+      document.getElementById(api + 'StatusFailed').innerHTML = '';
+  }
+
+  function setFailedMsg(msg, api) {
+      document.getElementById(api + 'StatusFailed').innerHTML = msg;
+      document.getElementById(api + 'StatusOk').innerHTML = '';
+  }
+
+  function testApi(api) {
+      let url = '/' + api + '/test';
+
+      fetchAsync(url).then(function(res) {
+          console.log(res);
+          let buildMsg;
+          if (res.status === "error") {
+              buildMsg = "Connection failed.";
+              setFailedMsg(buildMsg, api);
+          } else {
+              buildMsg = "Connection successful! ";
+              switch(api) {
+                  case "radarr":
+                  case "sonarr":
+                      buildMsg += "Version " + res.version;
+                      break;
+                  case "ombi":
+                      buildMsg += "Version " + res;
+                      break;
+              }
+
+              setSuccessMsg(buildMsg, api);
+          }
+      });
+
+  }
+  async function fetchAsync (url, api) {
+      let response = await fetch(url);
+      let data = await response.json();
+      if (api === "radarr") {
+
+      }
+      return data;
+      //console.log(data);
   }
 </script>

--- a/src/views/config.ejs
+++ b/src/views/config.ejs
@@ -171,10 +171,6 @@
       currentSetting = settingName;
   }
 
-  function test() {
-      console.log('hello');
-  }
-
   function setSuccessMsg(msg, api) {
       document.getElementById(api + 'StatusOk').innerHTML = msg;
       document.getElementById(api + 'StatusFailed').innerHTML = '';
@@ -189,10 +185,13 @@
       let url = '/' + api + '/test';
 
       fetchAsync(url).then(function(res) {
-          console.log(res);
           let buildMsg;
-          if (res.status === "error") {
-              buildMsg = "Connection failed.";
+          if ((res.status === "error")) {
+              buildMsg = "Connection failed. ";
+              if ((api === "tautulli")) {
+                  let detail = JSON.parse(res.response);
+                  buildMsg += detail.response.message;
+              }
               setFailedMsg(buildMsg, api);
           } else {
               buildMsg = "Connection successful! ";
@@ -200,9 +199,6 @@
                   case "radarr":
                   case "sonarr":
                       buildMsg += "Version " + res.version;
-                      break;
-                  case "ombi":
-                      buildMsg += "Version " + res;
                       break;
               }
 
@@ -218,6 +214,5 @@
 
       }
       return data;
-      //console.log(data);
   }
 </script>

--- a/src/views/config.ejs
+++ b/src/views/config.ejs
@@ -80,10 +80,25 @@
     <h2 class="h2-setting">Ombi Username</h2>
     <input type = "text" class = "form-control" name = "userName" value = "<% if (ombiSettings && ombiSettings.username) { %><%=ombiSettings.username %><% } %>">
     <p>(Enter Ombi username if you want custom permissions.)</p>
-    <button class = "btn btn-lg btn-primary btn-block" type = "submit" name = "submit">Submit</button>
-    <button class = "btn btn-lg btn-secondary btn-block" type = "button" onclick="testApi('ombi');" >Test API</button>
-    <span id="ombiStatusOk" style="font-weight:bold;color:green;"></span>
-    <span id="ombiStatusFailed" style="font-weight:bold;color:red;"></span>
+
+    <div class="row buttons">
+      <div class="col-sm-6">
+        <button class = "btn btn-lg btn-secondary" type = "button" onclick="testApi('ombi');" >Test API</button>
+      </div>
+      <div class="col-sm-6">
+        <button class = "btn btn-lg btn-primary" type = "submit" name = "submit">Submit</button>
+      </div>
+    </div>
+
+    <div class="alerts">
+      <div class="alert alert-success" id="ombiOk">
+        <span id="ombiStatusOk" class="ok"></span>
+      </div>
+      <div class="alert alert-danger" id="ombiFailed">
+        <span id="ombiStatusFailed" class="failed"></span>
+      </div>
+    </div>
+
   </form>
 </div>
 
@@ -104,10 +119,25 @@
       <label for="slide4"></label>
     </div>
     <h2 class="h2-setting">SSL</h2>
-    <button class = "btn btn-lg btn-primary btn-block" type = "submit" name = "submit">Submit</button>
-    <button class = "btn btn-lg btn-secondary btn-block" type = "button" onclick="testApi('tautulli');" >Test API</button>
-    <span id="tautulliStatusOk" style="font-weight:bold;color:green;"></span>
-    <span id="tautulliStatusFailed" style="font-weight:bold;color:red;"></span>
+
+    <div class="row buttons">
+      <div class="col-sm-6">
+        <button class = "btn btn-lg btn-secondary" type = "button" onclick="testApi('tautulli');" >Test API</button>
+      </div>
+      <div class="col-sm-6">
+        <button class = "btn btn-lg btn-primary" type = "submit" name = "submit">Submit</button>
+      </div>
+    </div>
+
+    <div class="alerts">
+      <div class="alert alert-success" id="tautulliOk">
+        <span id="tautulliStatusOk" class="ok"></span>
+      </div>
+      <div class="alert alert-danger" id="tautulliFailed">
+        <span id="tautulliStatusFailed" class="failed"></span>
+      </div>
+    </div>
+
   </form>
 </div>
 
@@ -128,10 +158,25 @@
       <label for="slide5"></label>
     </div>
     <h2 class="h2-setting">SSL</h2>
-    <button class = "btn btn-lg btn-primary btn-block" type = "submit" name = "submit">Submit</button>
-    <button class = "btn btn-lg btn-secondary btn-block" type = "button" onclick="testApi('sonarr');" >Test API</button>
-    <span id="sonarrStatusOk" style="font-weight:bold;color:green;"></span>
-    <span id="sonarrStatusFailed" style="font-weight:bold;color:red;"></span>
+
+    <div class="row buttons">
+      <div class="col-sm-6">
+        <button class = "btn btn-lg btn-secondary" type = "button" onclick="testApi('sonarr');" >Test API</button>
+      </div>
+      <div class="col-sm-6">
+        <button class = "btn btn-lg btn-primary" type = "submit" name = "submit">Submit</button>
+      </div>
+    </div>
+
+    <div class="alerts">
+      <div class="alert alert-success" id="sonarrOk">
+        <span id="sonarrStatusOk" class="ok"></span>
+      </div>
+      <div class="alert alert-danger" id="sonarrFailed">
+        <span id="sonarrStatusFailed" class="failed"></span>
+      </div>
+    </div>
+
   </form>
 </div>
 
@@ -152,10 +197,25 @@
       <label for="slide6"></label>
     </div>
     <h2 class="h2-setting">SSL</h2>
-    <button class = "btn btn-lg btn-primary btn-block" type = "submit" name = "submit">Submit</button>
-    <button class = "btn btn-lg btn-secondary btn-block" type = "button" onclick="testApi('radarr');" >Test API</button>
-    <span id="radarrStatusOk" style="font-weight:bold;color:green;"></span>
-    <span id="radarrStatusFailed" style="font-weight:bold;color:red;"></span>
+
+    <div class="row buttons">
+      <div class="col-sm-6">
+        <button class = "btn btn-lg btn-secondary" type = "button" onclick="testApi('radarr');" >Test API</button>
+      </div>
+      <div class="col-sm-6">
+        <button class = "btn btn-lg btn-primary" type = "submit" name = "submit">Submit</button>
+      </div>
+    </div>
+
+    <div class="alerts">
+      <div class="alert alert-success" id="radarrOk">
+        <span id="radarrStatusOk" class="ok"></span>
+      </div>
+      <div class="alert alert-danger" id="radarrFailed">
+        <span id="radarrStatusFailed" class="failed"></span>
+      </div>
+    </div>
+
   </form>
 </div>
 
@@ -171,11 +231,15 @@
   }
 
   function setSuccessMsg(msg, api) {
+      document.getElementById(api + 'Ok').style.display = "block";
+      document.getElementById(api + 'Failed').style.display = "none";
       document.getElementById(api + 'StatusOk').innerHTML = msg;
       document.getElementById(api + 'StatusFailed').innerHTML = '';
   }
 
   function setFailedMsg(msg, api) {
+      document.getElementById(api + 'Failed').style.display = "block";
+      document.getElementById(api + 'Ok').style.display = "none";
       document.getElementById(api + 'StatusFailed').innerHTML = msg;
       document.getElementById(api + 'StatusOk').innerHTML = '';
   }

--- a/src/views/styles/config.css
+++ b/src/views/styles/config.css
@@ -110,7 +110,25 @@ body {
     width: 50%;
     text-align: center;
 }
-
+.buttons button {
+    display: block;
+    width: 100%;
+}
+div.alerts{
+    margin-top: 10px;
+}
+div.alerts span {
+    font-weight: bold;
+}
+div.alerts span.ok {
+    color: green;
+}
+div.alerts span.failed {
+    color: red;
+}
+div.alerts div {
+    display:none;
+}
 h2 {
     color: #00aaff;
 }


### PR DESCRIPTION
Fixes #55.

Tests the current API credentials for each system (Ombi, Tautulli, Sonarr and Radarr).

You have to save the changes before testing them, as it reads the config settings directly from the DB when testing.

Currently for Ombi it requests the `/api/v1/Search/movie/popular` endpoint as `/api/v1/Status/info` doesn't require an API key - if anyone can think of a better endpoint to use I'm open to suggestions!

I have tested this on my local install, all seems OK.